### PR TITLE
Add ResetAllHeartsCommand command

### DIFF
--- a/src/main/java/org/fliff/lifeSteal/commands/ResetAllHeartsCommand.java
+++ b/src/main/java/org/fliff/lifeSteal/commands/ResetAllHeartsCommand.java
@@ -1,0 +1,83 @@
+package de.survivalnight.luna.lifeSteal.commands;
+
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import de.survivalnight.luna.lifeSteal.LifeSteal;
+import de.survivalnight.luna.lifeSteal.utils.ConfigManager;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+public class ResetAllHeartsCommand implements CommandExecutor {
+
+    private final ConfigManager configManager = new ConfigManager();
+    private final LifeSteal plugin;
+
+    public ResetAllHeartsCommand(LifeSteal plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission("lifesteal.resetall")) {
+            sender.sendMessage(configManager.formatMessage("&cYou don't have permission to use this command!"));
+            return true;
+        }
+
+        sender.sendMessage(configManager.formatMessage("&eResetting all players' hearts..."));
+
+        int onlineCount = 0;
+        int offlineCount = 0;
+        Set<UUID> offlinePlayerUUIDs = new HashSet<>();
+
+        // Reset all online players immediately
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            player.setMaxHealth(20);
+            player.setHealth(20);
+            onlineCount++;
+        }
+
+        // Collect all offline players
+        for (OfflinePlayer offlinePlayer : Bukkit.getOfflinePlayers()) {
+            // Only process players who have played before and are not currently online
+            if (offlinePlayer.hasPlayedBefore() && !offlinePlayer.isOnline()) {
+                offlinePlayerUUIDs.add(offlinePlayer.getUniqueId());
+                offlineCount++;
+            }
+        }
+
+        // Save offline player UUIDs to a file for processing on join
+        savePendingResets(offlinePlayerUUIDs);
+
+        sender.sendMessage(configManager.formatMessage("&aReset complete!"));
+        sender.sendMessage(configManager.formatMessage("&7Online players reset: &a" + onlineCount));
+        sender.sendMessage(configManager.formatMessage("&7Offline players queued: &a" + offlineCount));
+        sender.sendMessage(configManager.formatMessage("&7Offline players will be reset when they next join."));
+
+        return true;
+    }
+
+    private void savePendingResets(Set<UUID> uuids) {
+        File dataFolder = plugin.getDataFolder();
+        if (!dataFolder.exists()) {
+            dataFolder.mkdirs();
+        }
+
+        File pendingFile = new File(dataFolder, "pending_resets.txt");
+        try (FileWriter writer = new FileWriter(pendingFile, false)) {
+            for (UUID uuid : uuids) {
+                writer.write(uuid.toString() + "\n");
+            }
+        } catch (IOException e) {
+            plugin.getLogger().severe("Failed to save pending resets: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/org/fliff/lifeSteal/listeners/PlayerJoinListener.java
+++ b/src/main/java/org/fliff/lifeSteal/listeners/PlayerJoinListener.java
@@ -1,0 +1,80 @@
+package de.survivalnight.luna.lifeSteal.listeners;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import de.survivalnight.luna.lifeSteal.LifeSteal;
+import de.survivalnight.luna.lifeSteal.utils.ConfigManager;
+
+import java.io.*;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+public class PlayerJoinListener implements Listener {
+
+    private final LifeSteal plugin;
+    private final ConfigManager configManager = new ConfigManager();
+
+    public PlayerJoinListener(LifeSteal plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+        UUID playerUUID = player.getUniqueId();
+
+        Set<UUID> pendingResets = loadPendingResets();
+        
+        if (pendingResets.contains(playerUUID)) {
+            // Reset the player's hearts
+            player.setMaxHealth(20);
+            player.setHealth(20);
+            
+            // Remove this player from pending resets
+            pendingResets.remove(playerUUID);
+            savePendingResets(pendingResets);
+            
+            player.sendMessage(configManager.formatMessage("&aYour hearts have been reset!"));
+            plugin.getLogger().info("Reset hearts for player " + player.getName() + " (offline reset applied)");
+        }
+    }
+
+    private Set<UUID> loadPendingResets() {
+        Set<UUID> uuids = new HashSet<>();
+        File pendingFile = new File(plugin.getDataFolder(), "pending_resets.txt");
+        
+        if (!pendingFile.exists()) {
+            return uuids;
+        }
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(pendingFile))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                try {
+                    uuids.add(UUID.fromString(line.trim()));
+                } catch (IllegalArgumentException e) {
+                    plugin.getLogger().warning("Invalid UUID in pending resets: " + line);
+                }
+            }
+        } catch (IOException e) {
+            plugin.getLogger().severe("Failed to load pending resets: " + e.getMessage());
+        }
+
+        return uuids;
+    }
+
+    private void savePendingResets(Set<UUID> uuids) {
+        File pendingFile = new File(plugin.getDataFolder(), "pending_resets.txt");
+        
+        try (FileWriter writer = new FileWriter(pendingFile, false)) {
+            for (UUID uuid : uuids) {
+                writer.write(uuid.toString() + "\n");
+            }
+        } catch (IOException e) {
+            plugin.getLogger().severe("Failed to save pending resets: " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new feature to reset all players' hearts, both online and offline, in the LifeSteal plugin. The implementation includes a command for admins to trigger the reset and a listener to handle offline players when they rejoin. The most important changes are grouped below:

**New Command for Resetting Hearts**

* Added `ResetAllHeartsCommand` class, which allows admins to reset the hearts (health) of all online players immediately and queues offline players for reset when they next join.
* The command records offline players' UUIDs in a `pending_resets.txt` file for later processing.

**Offline Player Handling**

* Added `PlayerJoinListener` class, which checks if a joining player is in the pending reset list and resets their hearts if necessary, removing them from the queue afterward.
* Implemented file operations to load and update the pending resets list, ensuring offline players are handled reliably on their next login.

These changes provide a robust way to reset player health across both online and offline states, improving administrative control and player experience.